### PR TITLE
Example of focus problem with child windows - RMAC-6966

### DIFF
--- a/CefGlue.Demo.Avalonia/MainWindow.xaml
+++ b/CefGlue.Demo.Avalonia/MainWindow.xaml
@@ -3,7 +3,7 @@
         x:Class="Xilium.CefGlue.Demo.Avalonia.MainWindow"
         MinWidth="500"
         MinHeight="300"
-        Title="Avalonia CefGlue Demo">
+        Title="Avalonia CefGlue Demo">    
     <NativeMenu.Menu>
         <NativeMenu>
             <NativeMenuItem Header="File">
@@ -20,6 +20,7 @@
     </NativeMenu.Menu>
     
     <DockPanel>
+        <Button DockPanel.Dock="Right" Background="Transparent" x:Name="toggleWindows" >Toggle Window Visibility</Button>
         <Menu Name="mainMenu" DockPanel.Dock="Top">
             <MenuItem Header="_File">
                 <MenuItem Header="_New Tab" Click="OnNewTabMenuItemClick" />

--- a/CefGlue.Demo.Avalonia/MainWindow.xaml.cs
+++ b/CefGlue.Demo.Avalonia/MainWindow.xaml.cs
@@ -1,16 +1,21 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.Threading;
 using System;
 using System.Collections;
-using Xilium.CefGlue.Common;
+using System.Collections.Generic;
 
 namespace Xilium.CefGlue.Demo.Avalonia
 {
     public class MainWindow : Window
     {
+        private static bool IsChild = false;
+        private static bool IsChildrenVisible;
+        private static IList<MainWindow> ChildWindows = new List<MainWindow>();
+
         public MainWindow()
         {
             InitializeComponent();
@@ -28,6 +33,38 @@ namespace Xilium.CefGlue.Demo.Avalonia
 
             var mainMenu = this.FindControl<Menu>("mainMenu");
             mainMenu.AttachedToVisualTree += MenuAttached;
+
+            if (!IsChild)
+            {
+                IsChild = true;
+                for (var i = 0; i < 2; i++)
+                {
+                    var w = new MainWindow();
+                    ChildWindows.Add(w);
+                }
+            }
+
+            var btn = this.Find<Button>("toggleWindows");
+            btn.Click += Btn_Click;
+        }
+
+        private void Btn_Click(object sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            if (IsChildrenVisible)
+            {
+                foreach (var w in ChildWindows)
+                {
+                    w.Hide();
+                }
+            }
+            else
+            {
+                foreach (var w in ChildWindows)
+                {
+                    w.Show(this);
+                }
+            }
+            IsChildrenVisible = !IsChildrenVisible;
         }
 
         private void MenuAttached(object sender, VisualTreeAttachmentEventArgs e)
@@ -38,7 +75,7 @@ namespace Xilium.CefGlue.Demo.Avalonia
             }
         }
 
-        private BrowserView ActiveBrowserView => (BrowserView) this.FindControl<TabControl>("tabControl").SelectedContent;
+        private BrowserView ActiveBrowserView => (BrowserView)this.FindControl<TabControl>("tabControl").SelectedContent;
 
         private void CreateNewTab()
         {


### PR DESCRIPTION
Demo.Avalonia updated to add child windows to main window and reproduce the problem - once child windows are shown, we cannot type into main window.