### PR TITLE
memleak: auto release for Handler values

### DIFF
--- a/CefGlue.Interop.Gen/make_interop.py
+++ b/CefGlue.Interop.Gen/make_interop.py
@@ -496,6 +496,8 @@ def make_handler_g_body(cls):
         result.append(indent + 'lock (_roots)')
         result.append(indent + '{')
         result.append(indent + indent + 'found = _roots.TryGetValue((IntPtr)ptr, out value);')
+        result.append(indent + indent + '// as we\'re getting the ref from the outside, it\'s our responsibility to decrement it')
+        result.append(indent + indent + 'value.release(ptr);')
         result.append(indent + '}')
         result.append(indent + 'return found ? value : null;')
         result.append('}')

--- a/CefGlue/Classes.g/CefClient.g.cs
+++ b/CefGlue/Classes.g/CefClient.g.cs
@@ -25,6 +25,8 @@ namespace Xilium.CefGlue
             lock (_roots)
             {
                 found = _roots.TryGetValue((IntPtr)ptr, out value);
+                // as we're getting the ref from the outside, it's our responsibility to decrement it
+                value.release(ptr);
             }
             return found ? value : null;
         }

--- a/CefGlue/Classes.g/CefExtensionHandler.g.cs
+++ b/CefGlue/Classes.g/CefExtensionHandler.g.cs
@@ -25,6 +25,8 @@ namespace Xilium.CefGlue
             lock (_roots)
             {
                 found = _roots.TryGetValue((IntPtr)ptr, out value);
+                // as we're getting the ref from the outside, it's our responsibility to decrement it
+                value.release(ptr);
             }
             return found ? value : null;
         }

--- a/CefGlue/Classes.g/CefRequestContextHandler.g.cs
+++ b/CefGlue/Classes.g/CefRequestContextHandler.g.cs
@@ -25,6 +25,8 @@ namespace Xilium.CefGlue
             lock (_roots)
             {
                 found = _roots.TryGetValue((IntPtr)ptr, out value);
+                // as we're getting the ref from the outside, it's our responsibility to decrement it
+                value.release(ptr);
             }
             return found ? value : null;
         }

--- a/CefGlue/Classes.g/CefUrlRequestClient.g.cs
+++ b/CefGlue/Classes.g/CefUrlRequestClient.g.cs
@@ -25,6 +25,8 @@ namespace Xilium.CefGlue
             lock (_roots)
             {
                 found = _roots.TryGetValue((IntPtr)ptr, out value);
+                // as we're getting the ref from the outside, it's our responsibility to decrement it
+                value.release(ptr);
             }
             return found ? value : null;
         }

--- a/CefGlue/Classes.g/CefUserData.g.cs
+++ b/CefGlue/Classes.g/CefUserData.g.cs
@@ -25,6 +25,8 @@ namespace Xilium.CefGlue
             lock (_roots)
             {
                 found = _roots.TryGetValue((IntPtr)ptr, out value);
+                // as we're getting the ref from the outside, it's our responsibility to decrement it
+                value.release(ptr);
             }
             return found ? value : null;
         }

--- a/CefGlue/Classes.g/CefV8ArrayBufferReleaseCallback.g.cs
+++ b/CefGlue/Classes.g/CefV8ArrayBufferReleaseCallback.g.cs
@@ -25,6 +25,8 @@ namespace Xilium.CefGlue
             lock (_roots)
             {
                 found = _roots.TryGetValue((IntPtr)ptr, out value);
+                // as we're getting the ref from the outside, it's our responsibility to decrement it
+                value.release(ptr);
             }
             return found ? value : null;
         }

--- a/CefGlue/Classes.g/CefV8Handler.g.cs
+++ b/CefGlue/Classes.g/CefV8Handler.g.cs
@@ -25,6 +25,8 @@ namespace Xilium.CefGlue
             lock (_roots)
             {
                 found = _roots.TryGetValue((IntPtr)ptr, out value);
+                // as we're getting the ref from the outside, it's our responsibility to decrement it
+                value.release(ptr);
             }
             return found ? value : null;
         }


### PR DESCRIPTION
There are two main categories of objects interchanged between CEF and
.NET. These are defined in CefGlue as Proxies and Handlers.

Proxies are the most common category. These objects provide access on
.NET side to native objects created and owned by CEF. Memory-wise, they
matter little (the actual state memory is on the native side), so all
they need to do is call add_ref() and release() appropriately to ensure
that CEF doesn't release memory for which a proxy object is still alive
in the managed side.

Handler objects work in the opposite way. They ware created in the
managed side and provided to CEF, so that the native side can call
methods and read state from the managed side. Memory ownership is on the
managed side. The same add_ref() and release() semantics apply, with the
add-on that when the reference counter reaches zero, it's the managed
side's responsibility to cleanup the memory.

Due to the way RefCount pointers work in CEF, whenever an object is
passed to a function, it comes with an increased refcount and it's the
function's responsibility to decrease it when it stops using the object.

Handler objects' ref counter is used for native references only. When
the ref count is positive, the object gets pinned and GC is prevented.
Managed references don't need ref counter because any managed reference
is sufficient to prevent a GC (that's the basis for the GC...). So when
we take a Handler object back from CEF, we should immediately decrease the
ref counter (which was increased when the object was passed to us). One
way of ensuring that this isn't forgotten, is to move the release() call
right into the FromNative() constructor.