### PR TITLE
memleak: cleanup pending JS execution tasks upon browser disposal

### DIFF
--- a/CefGlue.Common/CommonBrowserAdapter.cs
+++ b/CefGlue.Common/CommonBrowserAdapter.cs
@@ -472,6 +472,8 @@ namespace Xilium.CefGlue.Common
 
             browser.Dispose();
 
+            _javascriptExecutionEngine.Dispose();
+
             BrowserHost = null;
             _cefClient = null;
             _browser = null;

--- a/CefGlue.Common/JavascriptExecution/JavascriptExecutionEngine.cs
+++ b/CefGlue.Common/JavascriptExecution/JavascriptExecutionEngine.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xilium.CefGlue.Common.Events;
 using Xilium.CefGlue.Common.Helpers;
@@ -11,7 +12,7 @@ using Xilium.CefGlue.Common.Shared.Serialization;
 
 namespace Xilium.CefGlue.Common.JavascriptExecution
 {
-    internal class JavascriptExecutionEngine
+    internal class JavascriptExecutionEngine : IDisposable
     {
         private static volatile int lastTaskId;
 
@@ -126,6 +127,17 @@ namespace Xilium.CefGlue.Common.JavascriptExecution
             {
                 _pendingTasks.TryRemove(taskId, out var _);
                 throw;
+            }
+        }
+
+        public void Dispose()
+        {
+            ContextCreated = null;
+            ContextReleased = null;
+            UncaughtException = null;
+            foreach (var task in _pendingTasks)
+            {
+                task.Value.TrySetCanceled();
             }
         }
     }

--- a/CefGlue.Interop.Gen/make_interop.py
+++ b/CefGlue.Interop.Gen/make_interop.py
@@ -496,6 +496,8 @@ def make_handler_g_body(cls):
         result.append(indent + 'lock (_roots)')
         result.append(indent + '{')
         result.append(indent + indent + 'found = _roots.TryGetValue((IntPtr)ptr, out value);')
+        result.append(indent + indent + '// as we\'re getting the ref from the outside, it\'s our responsibility to decrement it')
+        result.append(indent + indent + 'value.release(ptr);')
         result.append(indent + '}')
         result.append(indent + 'return found ? value : null;')
         result.append('}')

--- a/CefGlue/Classes.g/CefClient.g.cs
+++ b/CefGlue/Classes.g/CefClient.g.cs
@@ -25,6 +25,8 @@ namespace Xilium.CefGlue
             lock (_roots)
             {
                 found = _roots.TryGetValue((IntPtr)ptr, out value);
+                // as we're getting the ref from the outside, it's our responsibility to decrement it
+                value.release(ptr);
             }
             return found ? value : null;
         }

--- a/CefGlue/Classes.g/CefExtensionHandler.g.cs
+++ b/CefGlue/Classes.g/CefExtensionHandler.g.cs
@@ -25,6 +25,8 @@ namespace Xilium.CefGlue
             lock (_roots)
             {
                 found = _roots.TryGetValue((IntPtr)ptr, out value);
+                // as we're getting the ref from the outside, it's our responsibility to decrement it
+                value.release(ptr);
             }
             return found ? value : null;
         }

--- a/CefGlue/Classes.g/CefRequestContextHandler.g.cs
+++ b/CefGlue/Classes.g/CefRequestContextHandler.g.cs
@@ -25,6 +25,8 @@ namespace Xilium.CefGlue
             lock (_roots)
             {
                 found = _roots.TryGetValue((IntPtr)ptr, out value);
+                // as we're getting the ref from the outside, it's our responsibility to decrement it
+                value.release(ptr);
             }
             return found ? value : null;
         }

--- a/CefGlue/Classes.g/CefUrlRequestClient.g.cs
+++ b/CefGlue/Classes.g/CefUrlRequestClient.g.cs
@@ -25,6 +25,8 @@ namespace Xilium.CefGlue
             lock (_roots)
             {
                 found = _roots.TryGetValue((IntPtr)ptr, out value);
+                // as we're getting the ref from the outside, it's our responsibility to decrement it
+                value.release(ptr);
             }
             return found ? value : null;
         }

--- a/CefGlue/Classes.g/CefUserData.g.cs
+++ b/CefGlue/Classes.g/CefUserData.g.cs
@@ -25,6 +25,8 @@ namespace Xilium.CefGlue
             lock (_roots)
             {
                 found = _roots.TryGetValue((IntPtr)ptr, out value);
+                // as we're getting the ref from the outside, it's our responsibility to decrement it
+                value.release(ptr);
             }
             return found ? value : null;
         }

--- a/CefGlue/Classes.g/CefV8ArrayBufferReleaseCallback.g.cs
+++ b/CefGlue/Classes.g/CefV8ArrayBufferReleaseCallback.g.cs
@@ -25,6 +25,8 @@ namespace Xilium.CefGlue
             lock (_roots)
             {
                 found = _roots.TryGetValue((IntPtr)ptr, out value);
+                // as we're getting the ref from the outside, it's our responsibility to decrement it
+                value.release(ptr);
             }
             return found ? value : null;
         }

--- a/CefGlue/Classes.g/CefV8Handler.g.cs
+++ b/CefGlue/Classes.g/CefV8Handler.g.cs
@@ -25,6 +25,8 @@ namespace Xilium.CefGlue
             lock (_roots)
             {
                 found = _roots.TryGetValue((IntPtr)ptr, out value);
+                // as we're getting the ref from the outside, it's our responsibility to decrement it
+                value.release(ptr);
             }
             return found ? value : null;
         }


### PR DESCRIPTION
It's possible to ask a browser to execute some JavaScript and then close
it before the results came back. This would cause some Task objects to
be left waiting on a TaskCompletionSource that would never be marked
completed.

This CL clears up all pending TaskCompletionSources upon browser
disposal.