### PR TITLE
memleak: break object reference cycle so GC works

### DIFF
--- a/CefGlue.Common/CommonBrowserAdapter.cs
+++ b/CefGlue.Common/CommonBrowserAdapter.cs
@@ -473,6 +473,7 @@ namespace Xilium.CefGlue.Common
             browser.Dispose();
 
             _javascriptExecutionEngine.Dispose();
+            _objectRegistry.Dispose();
 
             BrowserHost = null;
             _cefClient = null;

--- a/CefGlue.Common/ObjectBinding/NativeObjectRegistry.cs
+++ b/CefGlue.Common/ObjectBinding/NativeObjectRegistry.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xilium.CefGlue.Common.Events;
@@ -5,7 +6,7 @@ using Xilium.CefGlue.Common.Shared.RendererProcessCommunication;
 
 namespace Xilium.CefGlue.Common.ObjectBinding
 {
-    internal class NativeObjectRegistry
+    internal class NativeObjectRegistry : IDisposable
     {
         private CefBrowser _browser;
         private readonly Dictionary<string, NativeObject> _registeredObjects = new Dictionary<string, NativeObject>();
@@ -96,6 +97,11 @@ namespace Xilium.CefGlue.Common.ObjectBinding
             var cefMessage = message.ToCefProcessMessage();
             // TODO target main frame?
             _browser.GetMainFrame().SendProcessMessage(CefProcessId.Browser, cefMessage);
+        }
+
+        public void Dispose()
+        {
+            _browser = null;
         }
     }
 }


### PR DESCRIPTION
The GC is smart enough to deal with reference cycles. But in this
particular case the GC can't work its magic, because the referential
cycle has a part in the native land, to which the GC has no visibility.

This cycle works with something like:

  CefBrowser -> [ native ] -> CefClient -> (...) -> CefBrowser

CefClient is kept active because there's a native reference to it, but
the GC doesn't know what a native reference is... all it knows is that
the object was pinned (we must pin it to keep the native reference
valid). So the GC only sees something like

  (pinned root) -> CefClient -> (...) -> CefBrowser

This prevents the GC from collecting CefBrowser, which prevents the
native reference from being cleared, which prevents CefClient to be
cleared.

We break this cycle by making objects along the chain (represented above
by "(...)") clear their reference to CefBrowser upon disposal.