### PR TITLE
LoadCefGlueBrowserProcess file from the currently executing assembly

### DIFF
--- a/CefGlue.Common/CefRuntimeLoader.cs
+++ b/CefGlue.Common/CefRuntimeLoader.cs
@@ -32,8 +32,10 @@ namespace Xilium.CefGlue.Common
             {
                 // The executing DLL might not be in the current domain directory (plugins scenario)
                 path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-                if(!TryGetSubprocessPath(path, out subprocessPath))
+                if (!TryGetSubprocessPath(path, out subprocessPath))
+                {
                     throw new FileNotFoundException($"Unable to find \"{subprocessPath}\"");
+                }
             }
 
             settings.BrowserSubprocessPath = subprocessPath;


### PR DESCRIPTION
Haven't seen any word regarding to contributing, so I hope this is accepted.

CefGlue is trying to load dependencies from `AppDomain.CurrentDomain.BaseDirectory` which works for most scenarios, but in case that the DLL that uses CefGlue is in another directory it won't work.
For example, in my case, I have an app that loads user plugins from a different directory, causing this to fail.

Let me know if any changes are required.