### PR TITLE
Unsubscribe to events on close and cleanup to release the references

### DIFF
--- a/CefGlue.Common.Shared/RendererProcessCommunication/PipeServer.cs
+++ b/CefGlue.Common.Shared/RendererProcessCommunication/PipeServer.cs
@@ -10,7 +10,7 @@ namespace Xilium.CefGlue.Common.Shared.RendererProcessCommunication
     {
         private const int MaxErrorsAllowed = 5;
 
-        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+        private CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
 
         public event Action<string> MessageReceived;
 
@@ -38,12 +38,18 @@ namespace Xilium.CefGlue.Common.Shared.RendererProcessCommunication
                         }
                     }
                 }
+
+                var cancellationTokenSource = _cancellationTokenSource;
+                _cancellationTokenSource = null;
+                cancellationTokenSource.Dispose();
             });
         }
 
         public void Dispose()
         {
-            _cancellationTokenSource.Cancel();
+            _cancellationTokenSource?.Cancel();
+            // release the MessageReceived handlers to prevent any possible memory leak
+            MessageReceived = null;
         }
 
         private void HandleClientConnected(Stream pipe)

--- a/CefGlue.Common/CommonBrowserAdapter.cs
+++ b/CefGlue.Common/CommonBrowserAdapter.cs
@@ -451,6 +451,8 @@ namespace Xilium.CefGlue.Common
                 return false; 
             }
 
+            Control.GotFocus -= HandleGotFocus;
+            Control.SizeChanged -= HandleControlSizeChanged;
             Control.DestroyRender();
             Cleanup(browser);
 
@@ -459,6 +461,11 @@ namespace Xilium.CefGlue.Common
 
         protected void Cleanup(CefBrowser browser)
         {
+            if (_crashServerPipe != null)
+            {
+                _crashServerPipe.MessageReceived -= OnChildProcessCrashed;    
+            }
+            
             _crashServerPipe?.Dispose();
 
             browser.Dispose();

--- a/CefGlue.Common/CommonBrowserAdapter.cs
+++ b/CefGlue.Common/CommonBrowserAdapter.cs
@@ -451,8 +451,6 @@ namespace Xilium.CefGlue.Common
                 return false; 
             }
 
-            Control.GotFocus -= HandleGotFocus;
-            Control.SizeChanged -= HandleControlSizeChanged;
             Control.DestroyRender();
             Cleanup(browser);
 
@@ -461,11 +459,6 @@ namespace Xilium.CefGlue.Common
 
         protected void Cleanup(CefBrowser browser)
         {
-            if (_crashServerPipe != null)
-            {
-                _crashServerPipe.MessageReceived -= OnChildProcessCrashed;    
-            }
-            
             _crashServerPipe?.Dispose();
 
             browser.Dispose();

--- a/CefGlue.Common/ObjectBinding/NativeObjectRegistry.cs
+++ b/CefGlue.Common/ObjectBinding/NativeObjectRegistry.cs
@@ -99,6 +99,11 @@ namespace Xilium.CefGlue.Common.ObjectBinding
 
         public void Dispose()
         {
+            lock (_registrationSyncRoot)
+            {
+                _registeredObjects.Clear();
+            }
+
             _browser = null;
         }
     }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
 
     <PropertyGroup>
         <PackageOutputPath>$(MSBuildProjectDirectory)\..\Nuget\output</PackageOutputPath>
-        <Version>91.4472.28</Version>
+        <Version>91.4472.29</Version>
         <Authors>XiliumHQ,OutSystems</Authors>
         <Product>CefGlue</Product>
         <AssemblyTitle>CefGlue</AssemblyTitle>


### PR DESCRIPTION
Solve leaks related with a few events that need to be unsubscribed when closing the browser
![image](https://user-images.githubusercontent.com/11468067/167124910-762c7e1e-1a22-4aa3-809a-6269323276a3.png)

Also release the references in the _registeredObjects dictionary:
<img width="645" alt="image" src="https://user-images.githubusercontent.com/11468067/167147709-4281f985-687f-4305-a3d8-1158c31b5cbc.png">
