### PR TITLE
RICT-5070 :: Fixing slow loading

### DIFF
--- a/CefGlue.Common/build/CefGlue.Common.targets
+++ b/CefGlue.Common/build/CefGlue.Common.targets
@@ -20,6 +20,27 @@
             <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
             <PublishState>Included</PublishState>
         </None>
+        <None Include="$(OutDir)/libEGL.dylib">
+            <Visible>false</Visible>
+            <Link>$(OutputDirectory)\$(CefGlueBrowserProcessDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+            <PublishState>Included</PublishState>
+        </None>
+        <None Include="$(OutDir)/libGLESv2.dylib">
+            <Visible>false</Visible>
+            <Link>$(OutputDirectory)\$(CefGlueBrowserProcessDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+            <PublishState>Included</PublishState>
+        </None>
+        <None Include="$(OutDir)/libvk_swiftshader.dylib">
+            <Visible>false</Visible>
+            <Link>$(OutputDirectory)\$(CefGlueBrowserProcessDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+            <PublishState>Included</PublishState>
+        </None>
     </ItemGroup>
     <ItemGroup>
         <None Include="@(CefGlueBrowserProcessFiles)">
@@ -30,14 +51,4 @@
             <PublishState>Included</PublishState>
         </None>
     </ItemGroup>
-
-    <Target Name="MoveCeflib" AfterTargets="Build" Condition="'$(CefGlueTargetPlatform)' == 'osx'">
-        <ItemGroup>
-            <FilesToMove Include="$(OutDir)\libEGL.dylib"/>
-            <FilesToMove Include="$(OutDir)\libGLESv2.dylib"/>
-            <FilesToMove Include="$(OutDir)\libvk_swiftshader.dylib"/>
-        </ItemGroup>
-        <Message Text="Moving Files @(FilesToMove)[$(ProjectFileName)]"/>
-        <Move SourceFiles="@(FilesToMove)" DestinationFolder="$(OutDir)\$(CefGlueBrowserProcessDir)\"/>
-    </Target>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
 
     <PropertyGroup>
         <PackageOutputPath>$(MSBuildProjectDirectory)\..\Nuget\output</PackageOutputPath>
-        <Version>106.5249.1</Version>
+        <Version>106.5249.2</Version>
         <Authors>XiliumHQ,OutSystems</Authors>
         <Product>CefGlue</Product>
         <AssemblyTitle>CefGlue</AssemblyTitle>


### PR DESCRIPTION
This approach will solve the target not being executed during the app bundle.
Drawbacks:
- The `libEGL.dylib`, `libGLESv2.dylib`, and `libvk_swiftshader.dylib` will be included in the root folder and in the CefGlueBrowserProcessDir, which will lead to an increase of around 14Mb