### PR TITLE
Fix Code On Linux X64

### DIFF
--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -6,10 +6,11 @@
     <AssemblyName>Xilium.CefGlue.BrowserProcess</AssemblyName>
     <RootNamespace>Xilium.CefGlue.BrowserProcess</RootNamespace>
     <Configurations>Debug;Release;Debug_WindowlessRender</Configurations>
-    <RuntimeIdentifiers>osx-x64;win-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>osx-x64;win-x64;linux-x64</RuntimeIdentifiers>
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsWindows Condition="$([MSBuild]::IsOSPlatform('Windows'))">True</IsWindows>
+    <IsLinux Condition="$([MSBuild]::IsOSPlatform('Linux'))">True</IsLinux>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,6 +34,7 @@
     <!-- Publish both platforms on Windows for packaging -->
     <Message Text="Publishing..." Importance="High" />
     <MSBuild Condition="$(IsWindows) == 'True'" Projects="CefGlue.BrowserProcess.csproj" Targets="Publish" Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework);IsPublishing=True;PublishTrimmed=True;RuntimeIdentifier=win-x64" />
+    <MSBuild Condition="$(IsLinux) == 'True'" Projects="CefGlue.BrowserProcess.csproj" Targets="Publish" Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework);IsPublishing=True;PublishTrimmed=True;RuntimeIdentifier=linux-x64" />
     <MSBuild Projects="CefGlue.BrowserProcess.csproj" Targets="Publish" Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework);IsPublishing=True;PublishTrimmed=True;RuntimeIdentifier=osx-x64" />
   </Target>
 </Project>

--- a/CefGlue.BrowserProcess/Helpers/NativeLibsLoader.cs
+++ b/CefGlue.BrowserProcess/Helpers/NativeLibsLoader.cs
@@ -25,6 +25,7 @@ namespace Xilium.CefGlue.BrowserProcess.Helpers
                 case CefRuntimePlatform.Windows:
                     extension = "dll";
                     break;
+
                 case CefRuntimePlatform.Linux:
                     extension = "so";
                     break;

--- a/CefGlue.BrowserProcess/Helpers/NativeLibsLoader.cs
+++ b/CefGlue.BrowserProcess/Helpers/NativeLibsLoader.cs
@@ -25,6 +25,9 @@ namespace Xilium.CefGlue.BrowserProcess.Helpers
                 case CefRuntimePlatform.Windows:
                     extension = "dll";
                     break;
+                case CefRuntimePlatform.Linux:
+                    extension = "so";
+                    break;
             }
 
             AssemblyLoadContext.Default.ResolvingUnmanagedDll += (_, libName) =>

--- a/CefGlue.Common/CefGlue.Common.csproj
+++ b/CefGlue.Common/CefGlue.Common.csproj
@@ -61,6 +61,10 @@
             <TfmSpecificPackageFile Include="..\CefGlue.BrowserProcess\bin\$(Configuration)\$(DotnetVersion)\osx-x64\publish\**\*">
                 <PackagePath>bin\osx</PackagePath>
             </TfmSpecificPackageFile>
+            
+            <TfmSpecificPackageFile Include="..\CefGlue.BrowserProcess\bin\$(Configuration)\$(DotnetVersion)\linux-x64\publish\**\*">
+                <PackagePath>bin\linux</PackagePath>
+            </TfmSpecificPackageFile>
         </ItemGroup>
     </Target>
 

--- a/CefGlue.Common/CefGlue.Common.csproj
+++ b/CefGlue.Common/CefGlue.Common.csproj
@@ -25,6 +25,7 @@
         <PackageReference Include="NLog" />
         <PackageReference PrivateAssets="None" Include="cef.redist.x64" />
         <PackageReference PrivateAssets="None" Include="cef.redist.osx64" />
+        <PackageReference PrivateAssets="None" Include="cef.redist.linux64" />
         <PackageReference Include="System.Text.Json" />
     </ItemGroup>
 

--- a/CefGlue.Common/build/CefGlue.Common.props
+++ b/CefGlue.Common/build/CefGlue.Common.props
@@ -1,13 +1,16 @@
 <Project>
     <PropertyGroup>
         <!-- adding the supported indentifiers to make bundle work properly -->
-        <RuntimeIdentifiers>osx-x64;win-x64</RuntimeIdentifiers>
+        <RuntimeIdentifiers>osx-x64;win-x64;linux-x64</RuntimeIdentifiers>
     </PropertyGroup>
     <PropertyGroup Condition="($([MSBuild]::IsOSPlatform('Windows')) and '$(RuntimeIdentifier)' == '') or '$(RuntimeIdentifier)' == 'win-x64'">
         <CefGlueTargetPlatform>win</CefGlueTargetPlatform>
     </PropertyGroup>
     <PropertyGroup Condition="($([MSBuild]::IsOSPlatform('OSX')) and '$(RuntimeIdentifier)' == '') or '$(RuntimeIdentifier)' == 'osx-x64'">
         <CefGlueTargetPlatform>osx</CefGlueTargetPlatform>
+    </PropertyGroup>
+        <PropertyGroup Condition="($([MSBuild]::IsOSPlatform('Linux')) and '$(RuntimeIdentifier)' == '') or '$(RuntimeIdentifier)' == 'linux-x64'">
+        <CefGlueTargetPlatform>linux</CefGlueTargetPlatform>
     </PropertyGroup>
     <ItemGroup Condition="'$(CefGlueTargetPlatform)' != ''">
         <CefGlueBrowserProcessFiles Include="$(MSBuildThisFileDirectory)..\bin\$(CefGlueTargetPlatform)\*" />

--- a/CefGlue.Common/build/CefGlue.Common.targets
+++ b/CefGlue.Common/build/CefGlue.Common.targets
@@ -12,6 +12,36 @@
             <PublishState>Included</PublishState>
         </None>
     </ItemGroup>
+        <ItemGroup Condition="'$(CefGlueTargetPlatform)' == 'linux'">
+        <None Include="@(CefRedistOSX64)">
+            <Visible>false</Visible>
+            <Link>$(OutputDirectory)%(RecursiveDir)%(FileName)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+            <PublishState>Included</PublishState>
+        </None>
+        <None Include="$(OutDir)\libEGL.so">
+            <Visible>false</Visible>
+            <Link>$(OutputDirectory)$(CefGlueBrowserProcessDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+            <PublishState>Included</PublishState>
+        </None>
+        <None Include="$(OutDir)\libGLESv2.so">
+            <Visible>false</Visible>
+            <Link>$(OutputDirectory)$(CefGlueBrowserProcessDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+            <PublishState>Included</PublishState>
+        </None>
+        <None Include="$(OutDir)\libvk_swiftshader.so">
+            <Visible>false</Visible>
+            <Link>$(OutputDirectory)$(CefGlueBrowserProcessDir)\%(RecursiveDir)%(FileName)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+            <PublishState>Included</PublishState>
+        </None>
+    </ItemGroup>
     <ItemGroup Condition="'$(CefGlueTargetPlatform)' == 'osx'">
         <None Include="@(CefRedistOSX64)">
             <Visible>false</Visible>

--- a/CefGlue.Common/build/CefGlue.Common.targets
+++ b/CefGlue.Common/build/CefGlue.Common.targets
@@ -12,8 +12,9 @@
             <PublishState>Included</PublishState>
         </None>
     </ItemGroup>
-        <ItemGroup Condition="'$(CefGlueTargetPlatform)' == 'linux'">
-        <None Include="@(CefRedistOSX64)">
+
+    <ItemGroup Condition="'$(CefGlueTargetPlatform)' == 'linux'">
+        <None Include="@(CefRedistLinux64)">
             <Visible>false</Visible>
             <Link>$(OutputDirectory)%(RecursiveDir)%(FileName)%(Extension)</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -42,6 +43,7 @@
             <PublishState>Included</PublishState>
         </None>
     </ItemGroup>
+    
     <ItemGroup Condition="'$(CefGlueTargetPlatform)' == 'osx'">
         <None Include="@(CefRedistOSX64)">
             <Visible>false</Visible>

--- a/CefGlue.CopyLocal.props
+++ b/CefGlue.CopyLocal.props
@@ -3,11 +3,12 @@
     <ItemGroup>
         <PackageReference Include="cef.redist.x64" />
         <PackageReference Include="cef.redist.osx64" />
+        <PackageReference Include="cef.redist.linux64" />
     </ItemGroup>
 
     <PropertyGroup>
         <BrowserProcessDir>$(MSBuildThisFileDirectory)CefGlue.BrowserProcess\bin\$(Configuration)\$(DotnetVersion)</BrowserProcessDir>
-        <RuntimeIdentifiers>osx-x64;win-x64</RuntimeIdentifiers>
+        <RuntimeIdentifiers>osx-x64;win-x64;linux-x64</RuntimeIdentifiers>
     </PropertyGroup>
 
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
@@ -15,6 +16,9 @@
     </PropertyGroup>
     <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
         <CefGlueTargetPlatform>osx</CefGlueTargetPlatform>
+    </PropertyGroup>
+    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
+        <CefGlueTargetPlatform>linux</CefGlueTargetPlatform>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(RuntimeIdentifier)' == ''">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
         <LangVersion>latest</LangVersion>
         <CefRedistVersion>106.0.26</CefRedistVersion>
         <CefRedistOSXVersion>106.0.26</CefRedistOSXVersion>
-        <CefRedistLinuxVersion>106.0.27-patch1</CefRedistLinuxVersion>
+        <CefRedistLinuxVersion>106.0.28</CefRedistLinuxVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
         <LangVersion>latest</LangVersion>
         <CefRedistVersion>106.0.26</CefRedistVersion>
         <CefRedistOSXVersion>106.0.26</CefRedistOSXVersion>
-        <CefRedistLinuxVersion>106.0.27</CefRedistLinuxVersion>
+        <CefRedistLinuxVersion>106.0.27-patch1</CefRedistLinuxVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,7 @@
         <LangVersion>latest</LangVersion>
         <CefRedistVersion>106.0.26</CefRedistVersion>
         <CefRedistOSXVersion>106.0.26</CefRedistOSXVersion>
+        <CefRedistLinuxVersion>106.0.27</CefRedistLinuxVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,7 @@
 
         <PackageVersion Include="cef.redist.x64" Version="$(CefRedistVersion)" />
         <PackageVersion Include="cef.redist.osx64" Version="$(CefRedistOSXVersion)" />
+        <PackageVersion Include="cef.redist.linux64" Version="$(CefRedistOSXVersion)" />
 
         <PackageVersion Include="nunit" Version="3.12.0" />
         <PackageVersion Include="NUnit3TestAdapter" Version="3.17.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,7 @@
 
         <PackageVersion Include="cef.redist.x64" Version="$(CefRedistVersion)" />
         <PackageVersion Include="cef.redist.osx64" Version="$(CefRedistOSXVersion)" />
-        <PackageVersion Include="cef.redist.linux64" Version="$(CefRedistOSXVersion)" />
+        <PackageVersion Include="cef.redist.linux64" Version="$(CefRedistLinuxVersion)" />
 
         <PackageVersion Include="nunit" Version="3.12.0" />
         <PackageVersion Include="NUnit3TestAdapter" Version="3.17.0" />


### PR DESCRIPTION
Fix NativeLibsLoader to allow Linux to run CefGlue.Tests

I did a bit of debugging of CefGlue.Tests, CefGlue.Common and CefGlue.Shared and the only thing stopping it from running was in NativeLibsLoader I did need to put the libcef.so in the run area. pre-built, but thats is another thing to look at or discuss