### PR TITLE
Fixed CefGlue packaging

### DIFF
--- a/CefGlue.Avalonia/CefGlue.Avalonia.csproj
+++ b/CefGlue.Avalonia/CefGlue.Avalonia.csproj
@@ -5,7 +5,6 @@
     <RootNamespace>Xilium.CefGlue.Avalonia</RootNamespace>
     <AssemblyName>Xilium.CefGlue.Avalonia</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Configurations>Debug;Release;Debug_WindowlessRender</Configurations>
     <PackageId>CefGlue.Avalonia$(PackageSuffix)</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>$(DotnetVersion)</TargetFramework>
     <AssemblyName>Xilium.CefGlue.BrowserProcess</AssemblyName>
     <RootNamespace>Xilium.CefGlue.BrowserProcess</RootNamespace>
-    <Configurations>Debug;Release;Debug_WindowlessRender</Configurations>
     <RuntimeIdentifiers>osx-x64;win-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -9,7 +9,7 @@
     <RuntimeIdentifiers>osx-x64;win-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <PublishCommonConfig>Configuration=$(Configuration);TargetFramework=$(TargetFramework);IsPublishing=True;PublishTrimmed=True;RuntimeIdentifier=</PublishCommonConfig>
+    <PublishCommonConfig>Configuration=$(Configuration);Platform=$(Platform);TargetFramework=$(TargetFramework);IsPublishing=True;PublishTrimmed=True;RuntimeIdentifier=</PublishCommonConfig>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CefGlue.Common.Shared/CefGlue.Common.Shared.csproj
+++ b/CefGlue.Common.Shared/CefGlue.Common.Shared.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>$(DotnetVersion)</TargetFramework>
     <AssemblyName>Xilium.CefGlue.Common.Shared</AssemblyName>
     <RootNamespace>Xilium.CefGlue.Common.Shared</RootNamespace>
-    <Configurations>Debug;Release;Debug_WindowlessRender</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CefGlue.Common/CefGlue.Common.csproj
+++ b/CefGlue.Common/CefGlue.Common.csproj
@@ -5,7 +5,6 @@
         <AssemblyName>Xilium.CefGlue.Common</AssemblyName>
         <RootNamespace>Xilium.CefGlue.Common</RootNamespace>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <Configurations>Debug;Release;Debug_WindowlessRender</Configurations>
         <PackageId>CefGlue.Common$(PackageSuffix)</PackageId>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>

--- a/CefGlue.Demo.Avalonia/CefGlue.Demo.Avalonia.csproj
+++ b/CefGlue.Demo.Avalonia/CefGlue.Demo.Avalonia.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>$(DotnetVersion)</TargetFramework>
     <AssemblyName>Xilium.CefGlue.Demo.Avalonia</AssemblyName>
     <RootNamespace>Xilium.CefGlue.Demo.Avalonia</RootNamespace>
-    <Configurations>Debug;Release;Debug_WindowlessRender</Configurations>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug_WindowlessRender'">

--- a/CefGlue.Demo.WPF/CefGlue.Demo.WPF.csproj
+++ b/CefGlue.Demo.WPF/CefGlue.Demo.WPF.csproj
@@ -5,7 +5,6 @@
         <TargetFramework>$(DotnetVersion)-windows</TargetFramework>
         <AssemblyName>Xilium.CefGlue.Demo.WPF</AssemblyName>
         <RootNamespace>Xilium.CefGlue.Demo.WPF</RootNamespace>
-        <Configurations>Debug;Release;Debug_WindowlessRender</Configurations>
         <UseWPF>true</UseWPF>
         <StartupObject>Xilium.CefGlue.Demo.WPF.Program</StartupObject>
         <EnableWindowsTargeting>true</EnableWindowsTargeting>

--- a/CefGlue.Tests/CefGlue.Tests.csproj
+++ b/CefGlue.Tests/CefGlue.Tests.csproj
@@ -3,15 +3,14 @@
   <PropertyGroup>
     <TargetFramework>$(DotnetVersion)</TargetFramework>
     <IsPackable>false</IsPackable>
-    <Configurations>Debug;Release;Debug_WindowlessRender</Configurations>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)'=='Debug_WindowlessRender'">
-    <DefineConstants>DEBUG</DefineConstants>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug_WindowlessRender'">
+    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <DefineConstants>DEBUG</DefineConstants>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CefGlue.WPF/CefGlue.WPF.csproj
+++ b/CefGlue.WPF/CefGlue.WPF.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(DotnetVersion)-windows</TargetFramework>
     <OutputType>Library</OutputType>
-    <Configurations>Debug;Release;Debug_WindowlessRender</Configurations>
     <RootNamespace>Xilium.CefGlue.WPF</RootNamespace>
     <AssemblyName>Xilium.CefGlue.WPF</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/CefGlue/CefGlue.csproj
+++ b/CefGlue/CefGlue.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(DotnetVersion)</TargetFramework>
     <AssemblyName>Xilium.CefGlue</AssemblyName>
-    <Configurations>Debug;Release;Debug_WindowlessRender</Configurations>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
 
     <PropertyGroup>
         <PackageOutputPath>$(MSBuildProjectDirectory)\..\Nuget\output</PackageOutputPath>
-        <Version>106.5249.19</Version>
+        <Version>106.5249.20</Version>
         <Authors>XiliumHQ,OutSystems</Authors>
         <Product>CefGlue</Product>
         <AssemblyTitle>CefGlue</AssemblyTitle>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,7 @@
         <CefRedistVersion>106.0.26</CefRedistVersion>
         <CefRedistOSXVersion>106.0.26-patch1</CefRedistOSXVersion>
         <Platforms>x64;ARM64</Platforms>
+        <Configurations>Debug;DebugWindowlessRender;Release;ReleaseWPFAvalonia</Configurations>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Debug symbols were being included in Windows: 

![image](https://github.com/OutSystems/CefGlue/assets/13751333/bd05c16e-cf1e-4743-bff2-109f710adf42)
