### PR TITLE
Osr scale fix

### DIFF
--- a/CefGlue.Avalonia/AvaloniaRenderSurface.cs
+++ b/CefGlue.Avalonia/AvaloniaRenderSurface.cs
@@ -48,8 +48,7 @@ namespace Xilium.CefGlue.Avalonia
         {
             // TODO handle transparency
             _bitmap?.Dispose();
-            // width & height are full resolution via actual Dpi then output is scaled in Viewbox container
-            _bitmap = new WriteableBitmap(new PixelSize(width, height), new Vector(DefaultDpi, DefaultDpi), PixelFormat.Bgra8888, AlphaFormat.Opaque);
+            _bitmap = new WriteableBitmap(new PixelSize(width, height), new Vector(DefaultDpi, DefaultDpi), PixelFormat.Bgra8888, AlphaFormat.Premul);
             Image.Source = _bitmap;
         }
 

--- a/CefGlue.Avalonia/AvaloniaRenderSurface.cs
+++ b/CefGlue.Avalonia/AvaloniaRenderSurface.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Threading.Tasks;
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using Avalonia.Threading;
+using System;
+using System.Threading.Tasks;
 using Xilium.CefGlue.Common.Helpers;
 
 namespace Xilium.CefGlue.Avalonia
@@ -48,7 +48,8 @@ namespace Xilium.CefGlue.Avalonia
         {
             // TODO handle transparency
             _bitmap?.Dispose();
-            _bitmap = new WriteableBitmap(new PixelSize(width, height), new Vector(Dpi, Dpi), PixelFormat.Bgra8888, AlphaFormat.Opaque);
+            // width & height are full resolution via actual Dpi then output is scaled in Viewbox container
+            _bitmap = new WriteableBitmap(new PixelSize(width, height), new Vector(DefaultDpi, DefaultDpi), PixelFormat.Bgra8888, AlphaFormat.Opaque);
             Image.Source = _bitmap;
         }
 

--- a/CefGlue.Avalonia/AvaloniaRenderSurface.cs
+++ b/CefGlue.Avalonia/AvaloniaRenderSurface.cs
@@ -48,7 +48,7 @@ namespace Xilium.CefGlue.Avalonia
         {
             // TODO handle transparency
             _bitmap?.Dispose();
-            _bitmap = new WriteableBitmap(new PixelSize(width, height), new Vector(DefaultDpi, DefaultDpi), PixelFormat.Bgra8888, AlphaFormat.Premul);
+            _bitmap = new WriteableBitmap(new PixelSize(width, height), new Vector(DefaultDpi, DefaultDpi), PixelFormat.Bgra8888, AlphaFormat.Opaque);
             Image.Source = _bitmap;
         }
 

--- a/CefGlue.Avalonia/Platform/AvaloniaOffScreenControlHost.cs
+++ b/CefGlue.Avalonia/Platform/AvaloniaOffScreenControlHost.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia;
+﻿using System;
+using System.Threading.Tasks;
+using Avalonia;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -6,8 +8,6 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Threading;
-using System;
-using System.Threading.Tasks;
 using Xilium.CefGlue.Common.Helpers;
 using Xilium.CefGlue.Common.Platform;
 
@@ -66,10 +66,8 @@ namespace Xilium.CefGlue.Avalonia.Platform
             control.AddHandler(DragDrop.DragOverEvent, OnDragOver);
             control.AddHandler(DragDrop.DropEvent, OnDrop);
 
-            control.AddHandler(Control.KeyDownEvent, OnKeyDown, RoutingStrategies.Tunnel);
-            control.AddHandler(Control.KeyUpEvent, OnKeyUp, RoutingStrategies.Tunnel);
-            //control.KeyDown += OnKeyDown;
-            //control.KeyUp += OnKeyUp;
+            control.KeyDown += OnKeyDown;
+            control.KeyUp += OnKeyUp;
             control.TextInput += OnTextInput;
 
             var image = CreateImage();

--- a/CefGlue.Avalonia/Platform/AvaloniaOffScreenControlHost.cs
+++ b/CefGlue.Avalonia/Platform/AvaloniaOffScreenControlHost.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia;
+using System;
+using System.Threading.Tasks;
+using Avalonia;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -6,8 +8,6 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Threading;
-using System;
-using System.Threading.Tasks;
 using Xilium.CefGlue.Common.Helpers;
 using Xilium.CefGlue.Common.Platform;
 

--- a/CefGlue.Avalonia/Platform/AvaloniaOffScreenControlHost.cs
+++ b/CefGlue.Avalonia/Platform/AvaloniaOffScreenControlHost.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -8,6 +6,8 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Threading;
+using System;
+using System.Threading.Tasks;
 using Xilium.CefGlue.Common.Helpers;
 using Xilium.CefGlue.Common.Platform;
 
@@ -193,12 +193,11 @@ namespace Xilium.CefGlue.Avalonia.Platform
             if (e.Root is Window newWindow)
             {
                 _windowStateChangedObservable = newWindow.GetPropertyChangedObservable(Window.WindowStateProperty).Subscribe(OnHostWindowStateChanged);
-
-                if (e.Root.RenderScaling != RenderSurface.DeviceScaleFactor)
-                {
-                    RenderSurface.DeviceScaleFactor = (float)e.Root.RenderScaling;
-                    ScreenInfoChanged?.Invoke(RenderSurface.DeviceScaleFactor);
-                }
+            }
+            if (e.Root.RenderScaling != RenderSurface.DeviceScaleFactor)
+            {
+                RenderSurface.DeviceScaleFactor = (float)e.Root.RenderScaling;
+                ScreenInfoChanged?.Invoke(RenderSurface.DeviceScaleFactor);
             }
         }
 

--- a/CefGlue.Common/Helpers/OffScreenRenderSurface.cs
+++ b/CefGlue.Common/Helpers/OffScreenRenderSurface.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO.MemoryMappedFiles;
 using System.Threading.Tasks;
 
@@ -9,7 +9,7 @@ namespace Xilium.CefGlue.Common.Helpers
     /// </summary>
     internal abstract class OffScreenRenderSurface : IDisposable
     {
-        private const int DefaultDpi = 96;
+        protected const int DefaultDpi = 96;
 
         private int _width;
         private int _height;
@@ -31,9 +31,9 @@ namespace Xilium.CefGlue.Common.Helpers
 
         public int Height => _height;
 
-        public int ScaledWidth => (int)(DeviceScaleFactor * _width);
+        public int ScaledWidth => (int)Math.Ceiling(DeviceScaleFactor * _width);
 
-        public int ScaledHeight => (int)(DeviceScaleFactor * _height);
+        public int ScaledHeight => (int)Math.Ceiling(DeviceScaleFactor * _height);
 
         public float DeviceScaleFactor { get; set; } = 1;
 


### PR DESCRIPTION
Updated OSR to use device scaling and added Viewbox container for Image host control. More info [here](https://github.com/OutSystems/WebView/issues/319#issuecomment-1825955499).

Here's an example at 350% scaling w/o this fix:
![osr_3 5x_no_scaling](https://github.com/OutSystems/CefGlue/assets/134575/d71ad277-535c-4acd-ac1c-357223aa785a)

W/ fix:
![osr_3 5x_w_scaling](https://github.com/OutSystems/CefGlue/assets/134575/7831ea91-2956-43dc-9b61-878c0daf923c)

Its subtle but hopefully you see the difference. 