### PR TITLE
Added app manifest

### DIFF
--- a/CefGlue.Demo.Avalonia/CefGlue.Demo.Avalonia.csproj
+++ b/CefGlue.Demo.Avalonia/CefGlue.Demo.Avalonia.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>Xilium.CefGlue.Demo.Avalonia</AssemblyName>
     <RootNamespace>Xilium.CefGlue.Demo.Avalonia</RootNamespace>
     <RollForward>Major</RollForward>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug_WindowlessRender'">

--- a/CefGlue.Demo.Avalonia/app.manifest
+++ b/CefGlue.Demo.Avalonia/app.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 and 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>


### PR DESCRIPTION
Without app manifest we run into the following error on startup ([line 186 of AvaloniaControl.cs](https://github.com/OutSystems/CefGlue/blob/main/CefGlue.Avalonia/Platform/AvaloniaControl.cs#L186)):

>  System.InvalidOperationException: "Unable to create child window for native control host. Application manifest with supported OS list might be required."

This started happening since avalonia upgrade and should only affect windows.

As recommended in https://github.com/AvaloniaUI/Avalonia/issues/8609, we should add app.manifest to fix this

