### PR TITLE
RDEV-6642 Make CefGlue SelfContained

### DIFF
--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -8,7 +8,7 @@
     <RuntimeIdentifiers>osx-x64;win-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <PublishCommonConfig>Configuration=$(Configuration);Platform=$(Platform);TargetFramework=$(TargetFramework);IsPublishing=True;PublishTrimmed=True;RuntimeIdentifier=</PublishCommonConfig>
+    <PublishCommonConfig>Configuration=$(Configuration);Platform=$(Platform);TargetFramework=$(TargetFramework);IsPublishing=True;PublishTrimmed=True;SelfContained=True;RuntimeIdentifier=</PublishCommonConfig>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
 
     <PropertyGroup>
         <PackageOutputPath>$(MSBuildProjectDirectory)\..\Nuget\output</PackageOutputPath>
-        <Version>120.6099.201</Version>
+        <Version>120.6099.202</Version>
         <Authors>XiliumHQ,OutSystems</Authors>
         <Product>CefGlue</Product>
         <AssemblyTitle>CefGlue</AssemblyTitle>


### PR DESCRIPTION
While testing ODC running on dotnet 8 we noticed that CefGlue needed the dotnet8 sdk installed to be able to run.
This was due to a breaking change in dotnet 8 which made some apps no longer self-contained by default: https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/runtimespecific-app-default