### PR TITLE
Increase stack size in windows OS

### DIFF
--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -39,7 +39,7 @@
       <VcvarsFile Condition="'$(Platform)' == 'x64'">vcvars64.bat</VcvarsFile>
       <VcvarsFile Condition="'$(Platform)' == 'ARM64'">vcvarsamd64_arm64.bat</VcvarsFile>
       <VcvarsLocation Condition="Exists($(DevEnvDir))">$(DevEnvDir)..\..\VC\Auxiliary\Build\</VcvarsLocation>
-      <VcvarsLocation Condition="!Exists($(DevEnvDir))">C:\Program Files\Microsoft Visual Studio\2022\Enterprise\</VcvarsLocation> <!-- Path used in Microsoft-hosted agents -->
+      <VcvarsLocation Condition="!Exists($(DevEnvDir))">C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\</VcvarsLocation> <!-- Path used in Microsoft-hosted agents -->
       <RunsEditBin Condition="$(VcvarsFile) != '' And $(SkipEditbin) == False And $([MSBuild]::IsOSPlatform('Windows'))">True</RunsEditBin>
     </PropertyGroup>
 
@@ -47,8 +47,7 @@
       This command aims at increasing the stack size of Xilium.CefGlue.BrowserProcess.exe to 8 MiBs, using the visual studio tool "editbin".
       Comment it only for development purposes.
     -->
-    <Exec Condition="Exists($(VcvarsLocation)) == True" Command="call dir /s &quot;$(VcvarsLocation)&quot;" />
-    <!--<Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(TargetDir)Xilium.CefGlue.BrowserProcess.exe&quot;&#xD;&#xA;" />-->
+    <Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(TargetDir)Xilium.CefGlue.BrowserProcess.exe&quot;&#xD;&#xA;" />
   </Target>
 
   <Target Name="PublishApp" AfterTargets="Editbin" Condition="'$(_AssemblyTimestampBeforeCompile)' != '$(_AssemblyTimestampAfterCompile)' and '$(IsPublishing)' != 'True'">

--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -39,7 +39,7 @@
       <VcvarsFile Condition="'$(Platform)' == 'x64'">vcvars64.bat</VcvarsFile>
       <VcvarsFile Condition="'$(Platform)' == 'ARM64'">vcvarsamd64_arm64.bat</VcvarsFile>
       <VcvarsLocation Condition="Exists($(DevEnvDir))">$(DevEnvDir)..\..\VC\Auxiliary\Build\</VcvarsLocation>
-      <VcvarsLocation Condition="!Exists($(DevEnvDir))">C:\Program Files\Microsoft Visual Studio\2022\Enterprise\SDK\ScopeCppSDK\VC\bin\</VcvarsLocation> <!-- Path used in Microsoft-hosted agents -->
+      <VcvarsLocation Condition="!Exists($(DevEnvDir))">C:\Program Files\Microsoft Visual Studio\2022\Enterprise\</VcvarsLocation> <!-- Path used in Microsoft-hosted agents -->
       <RunsEditBin Condition="$(VcvarsFile) != '' And $(SkipEditbin) == False And $([MSBuild]::IsOSPlatform('Windows'))">True</RunsEditBin>
     </PropertyGroup>
 

--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -47,10 +47,7 @@
       This command aims at increasing the stack size of Xilium.CefGlue.BrowserProcess.exe to 8 MiBs, using the visual studio tool "editbin".
       Comment it only for development purposes.
     -->
-    <Exec Condition="$(RunsEditBin) == True" Command="echo &quot;right here using $(VcvarsLocation)$(VcvarsFile)&quot;" />
     <Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(TargetDir)Xilium.CefGlue.BrowserProcess.exe&quot;&#xD;&#xA;" />
-    <Exec Condition="$(RunsEditBin) == True" Command="echo &quot;output ****&quot;" />
-    <Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; dumpbin /HEADERS &quot;$(TargetDir)Xilium.CefGlue.BrowserProcess.exe&quot;&#xD;&#xA;" />
   </Target>
 
   <Target Name="PublishApp" AfterTargets="Editbin" Condition="'$(_AssemblyTimestampBeforeCompile)' != '$(_AssemblyTimestampAfterCompile)' and '$(IsPublishing)' != 'True'">

--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -47,7 +47,7 @@
       This command aims at increasing the stack size of Xilium.CefGlue.BrowserProcess.exe to 8 MiBs, using the visual studio tool "editbin".
       Comment it only for development purposes.
     -->
-    <Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(TargetDir)$(AssemblyName).exe&quot;&#xD;&#xA;" />
+    <Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(TargetDir)Xilium.CefGlue.BrowserProcess.exe&quot;&#xD;&#xA;" />
   </Target>
 
   <Target Name="PublishApp" AfterTargets="Editbin" Condition="'$(_AssemblyTimestampBeforeCompile)' != '$(_AssemblyTimestampAfterCompile)' and '$(IsPublishing)' != 'True'">

--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -31,13 +31,15 @@
 
   <Target Name="Editbin" BeforeTargets="AfterBuild">
     <!--
-      Quick explanation: This targets runs on build, and currently 3 more times for each MSBuild command executed in the next target "PublishApp".
+      Quick explanation: This target runs after build, and currently 3 more times for each MSBuild command executed in the next target "PublishApp".
       We just want this target to be executed for windows specs.
     -->
 
     <PropertyGroup>
-      <Vcvars Condition="'$(Platform)' == 'x64'">vcvars64.bat</Vcvars>
-      <Vcvars Condition="'$(Platform)' == 'ARM64'">vcvarsamd64_arm64.bat</Vcvars>
+      <VcvarsFile Condition="'$(Platform)' == 'x64'">vcvars64.bat</VcvarsFile>
+      <VcvarsFile Condition="'$(Platform)' == 'ARM64'">vcvarsamd64_arm64.bat</VcvarsFile>
+      <VcvarsLocation Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)..\..\VC\Auxiliary\Build\</VcvarsLocation>
+      <VcvarsLocation Condition="'$(DevEnvDir)' == ''">C:\Program Files (x86)\Microsoft Visual Studio\</VcvarsLocation>
       <RunsEditBin Condition="$(Vcvars) != '' And $(SkipEditbin) == False And $([MSBuild]::IsOSPlatform('Windows'))">True</RunsEditBin>
     </PropertyGroup>
 
@@ -45,7 +47,9 @@
       This command aims at increasing the stack size of Xilium.CefGlue.BrowserProcess.exe to 8 MiBs, using the visual studio tool "editbin".
       Comment it only for development purposes.
     -->
-    <Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(DevEnvDir)..\..\VC\Auxiliary\Build\$(Vcvars)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(TargetDir)Xilium.CefGlue.BrowserProcess.exe&quot;&#xD;&#xA;" />
+    <Exec Command="echo ******************************************* $(VcvarsLocation)$(VcvarsFile)" />
+    <Exec Condition="Exists($(VcvarsLocation)) == True" Command="echo ******************************************* folder exists" />
+    <!--<Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(TargetDir)Xilium.CefGlue.BrowserProcess.exe&quot;&#xD;&#xA;" />-->
   </Target>
 
   <Target Name="PublishApp" AfterTargets="Editbin" Condition="'$(_AssemblyTimestampBeforeCompile)' != '$(_AssemblyTimestampAfterCompile)' and '$(IsPublishing)' != 'True'">

--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -40,14 +40,14 @@
       <VcvarsFile Condition="'$(Platform)' == 'ARM64'">vcvarsamd64_arm64.bat</VcvarsFile>
       <VcvarsLocation Condition="Exists($(DevEnvDir))">$(DevEnvDir)..\..\VC\Auxiliary\Build\</VcvarsLocation>
       <VcvarsLocation Condition="!Exists($(DevEnvDir))">C:\Program Files (x86)\Microsoft Visual Studio\</VcvarsLocation> <!-- Path used in Microsoft-hosted agents -->
-      <RunsEditBin Condition="$(Vcvars) != '' And $(SkipEditbin) == False And $([MSBuild]::IsOSPlatform('Windows'))">True</RunsEditBin>
+      <RunsEditBin Condition="$(VcvarsFile) != '' And $(SkipEditbin) == False And $([MSBuild]::IsOSPlatform('Windows'))">True</RunsEditBin>
     </PropertyGroup>
 
     <!--
       This command aims at increasing the stack size of Xilium.CefGlue.BrowserProcess.exe to 8 MiBs, using the visual studio tool "editbin".
       Comment it only for development purposes.
     -->
-    <Exec Condition="Exists($(VcvarsLocation)) == True" Command="call dir &quot;$(VcvarsLocation)&quot;" />
+    <Exec Condition="Exists($(VcvarsLocation)) == True" Command="call dir /s &quot;$(VcvarsLocation)&quot;" />
     <!--<Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(TargetDir)Xilium.CefGlue.BrowserProcess.exe&quot;&#xD;&#xA;" />-->
   </Target>
 

--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -38,8 +38,8 @@
     <PropertyGroup>
       <VcvarsFile Condition="'$(Platform)' == 'x64'">vcvars64.bat</VcvarsFile>
       <VcvarsFile Condition="'$(Platform)' == 'ARM64'">vcvarsamd64_arm64.bat</VcvarsFile>
-      <VcvarsLocation Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)..\..\VC\Auxiliary\Build\</VcvarsLocation>
-      <VcvarsLocation Condition="'$(DevEnvDir)' == ''">C:\Program Files (x86)\Microsoft Visual Studio\</VcvarsLocation>
+      <VcvarsLocation Condition="Exists($(DevEnvDir))">$(DevEnvDir)..\..\VC\Auxiliary\Build\</VcvarsLocation>
+      <VcvarsLocation Condition="!Exists($(DevEnvDir))">C:\Program Files (x86)\Microsoft Visual Studio\</VcvarsLocation>
       <RunsEditBin Condition="$(Vcvars) != '' And $(SkipEditbin) == False And $([MSBuild]::IsOSPlatform('Windows'))">True</RunsEditBin>
     </PropertyGroup>
 

--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -39,7 +39,7 @@
       <VcvarsFile Condition="'$(Platform)' == 'x64'">vcvars64.bat</VcvarsFile>
       <VcvarsFile Condition="'$(Platform)' == 'ARM64'">vcvarsamd64_arm64.bat</VcvarsFile>
       <VcvarsLocation Condition="Exists($(DevEnvDir))">$(DevEnvDir)..\..\VC\Auxiliary\Build\</VcvarsLocation>
-      <VcvarsLocation Condition="!Exists($(DevEnvDir))">C:\Program Files (x86)\Microsoft Visual Studio\</VcvarsLocation> <!-- Path used in Microsoft-hosted agents -->
+      <VcvarsLocation Condition="!Exists($(DevEnvDir))">C:\Program Files\Microsoft Visual Studio\2022\Enterprise\</VcvarsLocation> <!-- Path used in Microsoft-hosted agents -->
       <RunsEditBin Condition="$(VcvarsFile) != '' And $(SkipEditbin) == False And $([MSBuild]::IsOSPlatform('Windows'))">True</RunsEditBin>
     </PropertyGroup>
 

--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -9,7 +9,7 @@
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PublishCommonConfig>Configuration=$(Configuration);Platform=$(Platform);TargetFramework=$(TargetFramework);IsPublishing=True;PublishTrimmed=True;SelfContained=True;RuntimeIdentifier=</PublishCommonConfig>
-    <IsEditbinEnabled>False</IsEditbinEnabled>
+    <IsEditbinEnabled>True</IsEditbinEnabled>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -47,7 +47,10 @@
       This command aims at increasing the stack size of Xilium.CefGlue.BrowserProcess.exe to 8 MiBs, using the visual studio tool "editbin".
       Comment it only for development purposes.
     -->
+    <Exec Condition="$(RunsEditBin) == True" Command="echo &quot;right here using $(VcvarsLocation)$(VcvarsFile)&quot;" />
     <Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(TargetDir)Xilium.CefGlue.BrowserProcess.exe&quot;&#xD;&#xA;" />
+    <Exec Condition="$(RunsEditBin) == True" Command="echo &quot;output ****&quot;" />
+    <Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; dumpbin /HEADERS &quot;$(TargetDir)Xilium.CefGlue.BrowserProcess.exe&quot;&#xD;&#xA;" />
   </Target>
 
   <Target Name="PublishApp" AfterTargets="Editbin" Condition="'$(_AssemblyTimestampBeforeCompile)' != '$(_AssemblyTimestampAfterCompile)' and '$(IsPublishing)' != 'True'">

--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -47,7 +47,7 @@
       This command aims at increasing the stack size of Xilium.CefGlue.BrowserProcess.exe to 8 MiBs, using the visual studio tool "editbin".
       Comment it only for development purposes.
     -->
-    <Exec Condition="Exists($(VcvarsLocation)) == True" Command="echo ***** folder exists at '$(VcvarsLocation)'" />
+    <Exec Condition="Exists($(VcvarsLocation)) == True" Command="call dir &quot;$(VcvarsLocation)&quot;" />
     <!--<Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(TargetDir)Xilium.CefGlue.BrowserProcess.exe&quot;&#xD;&#xA;" />-->
   </Target>
 

--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -47,7 +47,7 @@
       This command aims at increasing the stack size of Xilium.CefGlue.BrowserProcess.exe to 8 MiBs, using the visual studio tool "editbin".
       Comment it only for development purposes.
     -->
-    <Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(TargetDir)Xilium.CefGlue.BrowserProcess.exe&quot;&#xD;&#xA;" />
+<!--    <Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(TargetDir)Xilium.CefGlue.BrowserProcess.exe&quot;&#xD;&#xA;" />-->
   </Target>
 
   <Target Name="PublishApp" AfterTargets="Editbin" Condition="'$(_AssemblyTimestampBeforeCompile)' != '$(_AssemblyTimestampAfterCompile)' and '$(IsPublishing)' != 'True'">

--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -9,6 +9,7 @@
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PublishCommonConfig>Configuration=$(Configuration);Platform=$(Platform);TargetFramework=$(TargetFramework);IsPublishing=True;PublishTrimmed=True;SelfContained=True;RuntimeIdentifier=</PublishCommonConfig>
+    <SkipEditbin>False</SkipEditbin>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,19 +28,37 @@
   <ItemGroup>
     <PackageReference Include="System.Runtime.Loader" />
   </ItemGroup>
-  
-  <Target Name="PublishApp" AfterTargets="AfterBuild" Condition="'$(_AssemblyTimestampBeforeCompile)' != '$(_AssemblyTimestampAfterCompile)' and '$(IsPublishing)' != 'True'">
 
+  <Target Name="Editbin" BeforeTargets="AfterBuild">
+    <!--
+      Quick explanation: This targets runs on build, and currently 3 more times for each MSBuild command executed in the next target "PublishApp".
+      We just want this target to be executed for windows specs.
+    -->
+
+    <PropertyGroup>
+      <Vcvars Condition="'$(Platform)' == 'x64'">vcvars64.bat</Vcvars>
+      <Vcvars Condition="'$(Platform)' == 'ARM64'">vcvarsamd64_arm64.bat</Vcvars>
+      <RunsEditBin Condition="$(Vcvars) != '' And $(SkipEditbin) == False And $([MSBuild]::IsOSPlatform('Windows'))">True</RunsEditBin>
+    </PropertyGroup>
+
+    <!--
+      This command aims at increasing the stack size of Xilium.CefGlue.BrowserProcess.exe to 8 MiBs, using the visual studio tool "editbin".
+      Comment it only for development purposes.
+    -->
+    <Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(DevEnvDir)..\..\VC\Auxiliary\Build\$(Vcvars)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(TargetDir)Xilium.CefGlue.BrowserProcess.exe&quot;&#xD;&#xA;" />
+  </Target>
+
+  <Target Name="PublishApp" AfterTargets="Editbin" Condition="'$(_AssemblyTimestampBeforeCompile)' != '$(_AssemblyTimestampAfterCompile)' and '$(IsPublishing)' != 'True'">
     <!-- WINDOWS -->
     <Message Text="Publishing CefGlue.BrowserProcess on Windows ($(Platform))..." Importance="High" />
-    <MSBuild Projects="CefGlue.BrowserProcess.csproj" Targets="Publish" Properties="$(PublishCommonConfig)win-$(ArchitectureConfig)" />
+    <MSBuild Projects="CefGlue.BrowserProcess.csproj" Targets="Publish" Properties="$(PublishCommonConfig)win-$(ArchitectureConfig);SkipEditbin=False;"  />
 
     <!-- LINUX -->
     <Message Text="Publishing CefGlue.BrowserProcess on Linux ($(Platform))..." Importance="High" />
-    <MSBuild Projects="CefGlue.BrowserProcess.csproj" Targets="Publish" Properties="$(PublishCommonConfig)linux-$(ArchitectureConfig)" />
-    
+    <MSBuild Projects="CefGlue.BrowserProcess.csproj" Targets="Publish" Properties="$(PublishCommonConfig)linux-$(ArchitectureConfig);SkipEditbin=True;" />
+
     <!-- OSX -->
     <Message Text="Publishing CefGlue.BrowserProcess on MacOS ($(Platform))..." Importance="High" />
-    <MSBuild Projects="CefGlue.BrowserProcess.csproj" Targets="Publish" Properties="$(PublishCommonConfig)osx-$(ArchitectureConfig)" />
+    <MSBuild Projects="CefGlue.BrowserProcess.csproj" Targets="Publish" Properties="$(PublishCommonConfig)osx-$(ArchitectureConfig);SkipEditbin=True;" />
   </Target>
 </Project>

--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -47,7 +47,7 @@
       This command aims at increasing the stack size of Xilium.CefGlue.BrowserProcess.exe to 8 MiBs, using the visual studio tool "editbin".
       Comment it only for development purposes.
     -->
-    <Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(TargetDir)Xilium.CefGlue.BrowserProcess.exe&quot;&#xD;&#xA;" />
+    <Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(TargetDir)$(AssemblyName).exe&quot;&#xD;&#xA;" />
   </Target>
 
   <Target Name="PublishApp" AfterTargets="Editbin" Condition="'$(_AssemblyTimestampBeforeCompile)' != '$(_AssemblyTimestampAfterCompile)' and '$(IsPublishing)' != 'True'">

--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -47,7 +47,7 @@
       This command aims at increasing the stack size of Xilium.CefGlue.BrowserProcess.exe to 8 MiBs, using the visual studio tool "editbin".
       Comment it only for development purposes.
     -->
-<!--    <Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(TargetDir)Xilium.CefGlue.BrowserProcess.exe&quot;&#xD;&#xA;" />-->
+    <Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(TargetDir)Xilium.CefGlue.BrowserProcess.exe&quot;&#xD;&#xA;" />
   </Target>
 
   <Target Name="PublishApp" AfterTargets="Editbin" Condition="'$(_AssemblyTimestampBeforeCompile)' != '$(_AssemblyTimestampAfterCompile)' and '$(IsPublishing)' != 'True'">

--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -9,7 +9,7 @@
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PublishCommonConfig>Configuration=$(Configuration);Platform=$(Platform);TargetFramework=$(TargetFramework);IsPublishing=True;PublishTrimmed=True;SelfContained=True;RuntimeIdentifier=</PublishCommonConfig>
-    <SkipEditbin>False</SkipEditbin>
+    <IsEditbinEnabled>False</IsEditbinEnabled>
   </PropertyGroup>
 
   <ItemGroup>
@@ -40,7 +40,7 @@
       <VcvarsFile Condition="'$(Platform)' == 'ARM64'">vcvarsamd64_arm64.bat</VcvarsFile>
       <VcvarsLocation Condition="Exists($(DevEnvDir))">$(DevEnvDir)..\..\VC\Auxiliary\Build\</VcvarsLocation>
       <VcvarsLocation Condition="!Exists($(DevEnvDir))">C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\</VcvarsLocation> <!-- Path used in Microsoft-hosted agents -->
-      <RunsEditBin Condition="$(VcvarsFile) != '' And $(SkipEditbin) == False And $([MSBuild]::IsOSPlatform('Windows'))">True</RunsEditBin>
+      <RunsEditBin Condition="$(VcvarsFile) != '' And $(IsEditbinEnabled) == True And $([MSBuild]::IsOSPlatform('Windows'))">True</RunsEditBin>
     </PropertyGroup>
 
     <!--
@@ -53,14 +53,14 @@
   <Target Name="PublishApp" AfterTargets="Editbin" Condition="'$(_AssemblyTimestampBeforeCompile)' != '$(_AssemblyTimestampAfterCompile)' and '$(IsPublishing)' != 'True'">
     <!-- WINDOWS -->
     <Message Text="Publishing CefGlue.BrowserProcess on Windows ($(Platform))..." Importance="High" />
-    <MSBuild Projects="CefGlue.BrowserProcess.csproj" Targets="Publish" Properties="$(PublishCommonConfig)win-$(ArchitectureConfig);SkipEditbin=False;"  />
+    <MSBuild Projects="CefGlue.BrowserProcess.csproj" Targets="Publish" Properties="$(PublishCommonConfig)win-$(ArchitectureConfig);IsEditbinEnabled=True;"  />
 
     <!-- LINUX -->
     <Message Text="Publishing CefGlue.BrowserProcess on Linux ($(Platform))..." Importance="High" />
-    <MSBuild Projects="CefGlue.BrowserProcess.csproj" Targets="Publish" Properties="$(PublishCommonConfig)linux-$(ArchitectureConfig);SkipEditbin=True;" />
+    <MSBuild Projects="CefGlue.BrowserProcess.csproj" Targets="Publish" Properties="$(PublishCommonConfig)linux-$(ArchitectureConfig);IsEditbinEnabled=False;" />
 
     <!-- OSX -->
     <Message Text="Publishing CefGlue.BrowserProcess on MacOS ($(Platform))..." Importance="High" />
-    <MSBuild Projects="CefGlue.BrowserProcess.csproj" Targets="Publish" Properties="$(PublishCommonConfig)osx-$(ArchitectureConfig);SkipEditbin=True;" />
+    <MSBuild Projects="CefGlue.BrowserProcess.csproj" Targets="Publish" Properties="$(PublishCommonConfig)osx-$(ArchitectureConfig);IsEditbinEnabled=False;" />
   </Target>
 </Project>

--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -39,7 +39,7 @@
       <VcvarsFile Condition="'$(Platform)' == 'x64'">vcvars64.bat</VcvarsFile>
       <VcvarsFile Condition="'$(Platform)' == 'ARM64'">vcvarsamd64_arm64.bat</VcvarsFile>
       <VcvarsLocation Condition="Exists($(DevEnvDir))">$(DevEnvDir)..\..\VC\Auxiliary\Build\</VcvarsLocation>
-      <VcvarsLocation Condition="!Exists($(DevEnvDir))">C:\Program Files (x86)\Microsoft Visual Studio\</VcvarsLocation>
+      <VcvarsLocation Condition="!Exists($(DevEnvDir))">C:\Program Files (x86)\Microsoft Visual Studio\</VcvarsLocation> <!-- Path used in Microsoft-hosted agents -->
       <RunsEditBin Condition="$(Vcvars) != '' And $(SkipEditbin) == False And $([MSBuild]::IsOSPlatform('Windows'))">True</RunsEditBin>
     </PropertyGroup>
 
@@ -47,8 +47,7 @@
       This command aims at increasing the stack size of Xilium.CefGlue.BrowserProcess.exe to 8 MiBs, using the visual studio tool "editbin".
       Comment it only for development purposes.
     -->
-    <Exec Command="echo ******************************************* $(VcvarsLocation)$(VcvarsFile)" />
-    <Exec Condition="Exists($(VcvarsLocation)) == True" Command="echo ******************************************* folder exists" />
+    <Exec Condition="Exists($(VcvarsLocation)) == True" Command="echo ***** folder exists at '$(VcvarsLocation)'" />
     <!--<Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(TargetDir)Xilium.CefGlue.BrowserProcess.exe&quot;&#xD;&#xA;" />-->
   </Target>
 

--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -39,7 +39,7 @@
       <VcvarsFile Condition="'$(Platform)' == 'x64'">vcvars64.bat</VcvarsFile>
       <VcvarsFile Condition="'$(Platform)' == 'ARM64'">vcvarsamd64_arm64.bat</VcvarsFile>
       <VcvarsLocation Condition="Exists($(DevEnvDir))">$(DevEnvDir)..\..\VC\Auxiliary\Build\</VcvarsLocation>
-      <VcvarsLocation Condition="!Exists($(DevEnvDir))">C:\Program Files\Microsoft Visual Studio\2022\Enterprise\</VcvarsLocation> <!-- Path used in Microsoft-hosted agents -->
+      <VcvarsLocation Condition="!Exists($(DevEnvDir))">C:\Program Files\Microsoft Visual Studio\2022\Enterprise\SDK\ScopeCppSDK\VC\bin\</VcvarsLocation> <!-- Path used in Microsoft-hosted agents -->
       <RunsEditBin Condition="$(VcvarsFile) != '' And $(SkipEditbin) == False And $([MSBuild]::IsOSPlatform('Windows'))">True</RunsEditBin>
     </PropertyGroup>
 

--- a/CefGlue.Tests/CefGlue.Tests.csproj
+++ b/CefGlue.Tests/CefGlue.Tests.csproj
@@ -42,4 +42,8 @@
   <Import Project="$(ProjectDir)..\CefGlue.CopyLocal.props" />
   <Import Project="$(ProjectDir)..\CefGlue.Common\build\CefGlue.Common.targets" />
 
+  <Target Name="CustomTarget" BeforeTargets="AfterBuild">
+    <Exec Command="dir /s ." />
+  </Target>
+  
 </Project>

--- a/CefGlue.Tests/CefGlue.Tests.csproj
+++ b/CefGlue.Tests/CefGlue.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project>
 
   <PropertyGroup>
     <TargetFramework>$(DotnetVersion)</TargetFramework>

--- a/CefGlue.Tests/CefGlue.Tests.csproj
+++ b/CefGlue.Tests/CefGlue.Tests.csproj
@@ -42,13 +42,13 @@
   <Import Project="$(ProjectDir)..\CefGlue.CopyLocal.props" />
   <Import Project="$(ProjectDir)..\CefGlue.Common\build\CefGlue.Common.targets" />
 
-  <Target Name="CustomTarget" BeforeTargets="AfterBuild">
-    <Exec Command="echo hello $(ProjectDir)..\CefGlue.CopyLocal.props" />
-    <Exec Command="echo hello $(ProjectDir)..\CefGlue.Common\build\CefGlue.Common.targets" />
+<!--  <Target Name="CustomTarget" BeforeTargets="AfterBuild">-->
+<!--    <Exec Command="echo hello $(ProjectDir)..\CefGlue.CopyLocal.props" />-->
+<!--    <Exec Command="echo hello $(ProjectDir)..\CefGlue.Common\build\CefGlue.Common.targets" />-->
 
-    <Exec Condition="Exists('$(ProjectDir)..\CefGlue.CopyLocal.props')" Command="echo first exists" />
-    <Exec Condition="Exists('$(ProjectDir)..\CefGlue.Common\build\CefGlue.Common.targets')" Command="echo second exists" />
-    <Exec Command="dir /s ." />
-  </Target>
+<!--    <Exec Condition="Exists('$(ProjectDir)..\CefGlue.CopyLocal.props')" Command="echo first exists" />-->
+<!--    <Exec Condition="Exists('$(ProjectDir)..\CefGlue.Common\build\CefGlue.Common.targets')" Command="echo second exists" />-->
+<!--    <Exec Command="dir /s ." />-->
+<!--  </Target>-->
   
 </Project>

--- a/CefGlue.Tests/CefGlue.Tests.csproj
+++ b/CefGlue.Tests/CefGlue.Tests.csproj
@@ -42,13 +42,4 @@
   <Import Project="$(ProjectDir)..\CefGlue.CopyLocal.props" />
   <Import Project="$(ProjectDir)..\CefGlue.Common\build\CefGlue.Common.targets" />
 
-  <Target Name="CustomTarget" BeforeTargets="AfterBuild">
-    <Exec Command="echo hello $(ProjectDir)..\CefGlue.CopyLocal.props" />
-    <Exec Command="echo hello $(ProjectDir)..\CefGlue.Common\build\CefGlue.Common.targets" />
-
-    <Exec Condition="Exists('$(ProjectDir)..\CefGlue.CopyLocal.props')" Command="echo first exists" />
-    <Exec Condition="Exists('$(ProjectDir)..\CefGlue.Common\build\CefGlue.Common.targets')" Command="echo second exists" />
-    <Exec Command="dir /s ." />
-  </Target>
-  
 </Project>

--- a/CefGlue.Tests/CefGlue.Tests.csproj
+++ b/CefGlue.Tests/CefGlue.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project>
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DotnetVersion)</TargetFramework>

--- a/CefGlue.Tests/CefGlue.Tests.csproj
+++ b/CefGlue.Tests/CefGlue.Tests.csproj
@@ -43,6 +43,11 @@
   <Import Project="$(ProjectDir)..\CefGlue.Common\build\CefGlue.Common.targets" />
 
   <Target Name="CustomTarget" BeforeTargets="AfterBuild">
+    <Exec Command="echo hello $(ProjectDir)..\CefGlue.CopyLocal.props" />
+    <Exec Command="echo hello $(ProjectDir)..\CefGlue.Common\build\CefGlue.Common.targets" />
+
+    <Exec Condition="Exists('$(ProjectDir)..\CefGlue.CopyLocal.props')" Command="echo first exists" />
+    <Exec Condition="Exists('$(ProjectDir)..\CefGlue.Common\build\CefGlue.Common.targets')" Command="echo second exists" />
     <Exec Command="dir /s ." />
   </Target>
   

--- a/CefGlue.Tests/CefGlue.Tests.csproj
+++ b/CefGlue.Tests/CefGlue.Tests.csproj
@@ -42,13 +42,13 @@
   <Import Project="$(ProjectDir)..\CefGlue.CopyLocal.props" />
   <Import Project="$(ProjectDir)..\CefGlue.Common\build\CefGlue.Common.targets" />
 
-<!--  <Target Name="CustomTarget" BeforeTargets="AfterBuild">-->
-<!--    <Exec Command="echo hello $(ProjectDir)..\CefGlue.CopyLocal.props" />-->
-<!--    <Exec Command="echo hello $(ProjectDir)..\CefGlue.Common\build\CefGlue.Common.targets" />-->
+  <Target Name="CustomTarget" BeforeTargets="AfterBuild">
+    <Exec Command="echo hello $(ProjectDir)..\CefGlue.CopyLocal.props" />
+    <Exec Command="echo hello $(ProjectDir)..\CefGlue.Common\build\CefGlue.Common.targets" />
 
-<!--    <Exec Condition="Exists('$(ProjectDir)..\CefGlue.CopyLocal.props')" Command="echo first exists" />-->
-<!--    <Exec Condition="Exists('$(ProjectDir)..\CefGlue.Common\build\CefGlue.Common.targets')" Command="echo second exists" />-->
-<!--    <Exec Command="dir /s ." />-->
-<!--  </Target>-->
+    <Exec Condition="Exists('$(ProjectDir)..\CefGlue.CopyLocal.props')" Command="echo first exists" />
+    <Exec Condition="Exists('$(ProjectDir)..\CefGlue.Common\build\CefGlue.Common.targets')" Command="echo second exists" />
+    <Exec Command="dir /s ." />
+  </Target>
   
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
 
     <PropertyGroup>
         <PackageOutputPath>$(MSBuildProjectDirectory)\..\Nuget\output</PackageOutputPath>
-        <Version>120.6099.205</Version>
+        <Version>120.6099.206</Version>
         <Authors>XiliumHQ,OutSystems</Authors>
         <Product>CefGlue</Product>
         <AssemblyTitle>CefGlue</AssemblyTitle>


### PR DESCRIPTION
# Description

Following https://github.com/chromiumembedded/cef/issues/3250 and https://bitbucket.org/chromiumembedded/cef/commits/85c53029bf07, this PR aims at increasing the cef stack size to 8 MiBs. To do so, we use the visual studio tool "editbin".

Similarly to https://github.com/cefsharp/CefSharp/blob/d0486b317967fe4a3eb00e783c26d93d2a00e594/CefSharp.BrowserSubprocess/CefSharp.BrowserSubprocess.netcore.csproj#L67, we want to run editbin after building to increase the stack size to 8 MiBs.

Differenly from the link above, I tried drying the code a bit and make it more readable.

# Results
To see a file's stack size, we can use `dumpbin` (another vs tool).
<img width="935" alt="Screenshot 2024-10-16 at 14 28 47" src="https://github.com/user-attachments/assets/826e8ce2-9183-4cf2-b105-e08d42e3c02b">

## Output of the `Xilium.CefGlue.BrowserProcess.exe` file before changes

<img width="534" alt="Screenshot 2024-10-16 at 14 29 58" src="https://github.com/user-attachments/assets/6c57b1d3-1f50-48e4-884a-fcab01effbe1">

## Output of the `Xilium.CefGlue.BrowserProcess.exe` file after changes
<img width="672" alt="Screenshot 2024-10-16 at 14 30 40" src="https://github.com/user-attachments/assets/53a17527-b98f-4406-af61-38d7188a0fb3">
