### PR TITLE
Increase stack size in windows OS (fixes #171)

### DIFF
--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="System.Runtime.Loader" />
   </ItemGroup>
 
-  <Target Name="Editbin" BeforeTargets="AfterBuild">
+  <Target Name="Editbin" AfterTargets="Compile">
     <!--
       Quick explanation: This target runs after build, and currently 3 more times for each MSBuild command executed in the next target "PublishApp".
       We just want this target to be executed for windows specs.
@@ -41,19 +41,21 @@
       <VcvarsLocation Condition="Exists($(DevEnvDir))">$(DevEnvDir)..\..\VC\Auxiliary\Build\</VcvarsLocation>
       <VcvarsLocation Condition="!Exists($(DevEnvDir))">C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\</VcvarsLocation> <!-- Path used in Microsoft-hosted agents -->
       <RunsEditBin Condition="$(VcvarsFile) != '' And $(IsEditbinEnabled) == True And $([MSBuild]::IsOSPlatform('Windows'))">True</RunsEditBin>
+      <ApphostLocation>$(ProjectDir)$(BaseIntermediateOutputPath)$(Platform)\$(Configuration)\$(TargetFramework)\</ApphostLocation>
+      <ApphostLocation Condition="'$(IsPublishing)' == 'True'">$(ApphostLocation)$(RuntimeIdentifier)\</ApphostLocation>
     </PropertyGroup>
 
     <!--
       This command aims at increasing the stack size of Xilium.CefGlue.BrowserProcess.exe to 8 MiBs, using the visual studio tool "editbin".
       Comment it only for development purposes.
     -->
-    <Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(TargetDir)Xilium.CefGlue.BrowserProcess.exe&quot;&#xD;&#xA;" />
+    <Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(ApphostLocation)\apphost.exe&quot;&#xD;&#xA;" />
   </Target>
 
-  <Target Name="PublishApp" AfterTargets="Editbin" Condition="'$(_AssemblyTimestampBeforeCompile)' != '$(_AssemblyTimestampAfterCompile)' and '$(IsPublishing)' != 'True'">
+  <Target Name="PublishApp" AfterTargets="AfterBuild" Condition="'$(_AssemblyTimestampBeforeCompile)' != '$(_AssemblyTimestampAfterCompile)' and '$(IsPublishing)' != 'True'">
     <!-- WINDOWS -->
     <Message Text="Publishing CefGlue.BrowserProcess on Windows ($(Platform))..." Importance="High" />
-    <MSBuild Projects="CefGlue.BrowserProcess.csproj" Targets="Publish" Properties="$(PublishCommonConfig)win-$(ArchitectureConfig);IsEditbinEnabled=True;"  />
+    <MSBuild Projects="CefGlue.BrowserProcess.csproj" Targets="Publish" Properties="$(PublishCommonConfig)win-$(ArchitectureConfig);IsEditbinEnabled=True;" />
 
     <!-- LINUX -->
     <Message Text="Publishing CefGlue.BrowserProcess on Linux ($(Platform))..." Importance="High" />

--- a/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
+++ b/CefGlue.BrowserProcess/CefGlue.BrowserProcess.csproj
@@ -31,22 +31,22 @@
 
   <Target Name="Editbin" AfterTargets="Compile">
     <!--
-      Quick explanation: This target runs after build, and currently 3 more times for each MSBuild command executed in the next target "PublishApp".
+      Quick explanation: This target runs after compile, and currently 3 more times for each MSBuild command executed in the next target "PublishApp".
       We just want this target to be executed for windows specs.
     -->
 
     <PropertyGroup>
       <VcvarsFile Condition="'$(Platform)' == 'x64'">vcvars64.bat</VcvarsFile>
-      <VcvarsFile Condition="'$(Platform)' == 'ARM64'">vcvarsamd64_arm64.bat</VcvarsFile>
       <VcvarsLocation Condition="Exists($(DevEnvDir))">$(DevEnvDir)..\..\VC\Auxiliary\Build\</VcvarsLocation>
       <VcvarsLocation Condition="!Exists($(DevEnvDir))">C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\</VcvarsLocation> <!-- Path used in Microsoft-hosted agents -->
       <RunsEditBin Condition="$(VcvarsFile) != '' And $(IsEditbinEnabled) == True And $([MSBuild]::IsOSPlatform('Windows'))">True</RunsEditBin>
       <ApphostLocation>$(ProjectDir)$(BaseIntermediateOutputPath)$(Platform)\$(Configuration)\$(TargetFramework)\</ApphostLocation>
-      <ApphostLocation Condition="'$(IsPublishing)' == 'True'">$(ApphostLocation)$(RuntimeIdentifier)\</ApphostLocation>
+      <ApphostLocation Condition="'$(IsPublishing)' == 'True'">$(ApphostLocation)$(RuntimeIdentifier)\</ApphostLocation> <!-- When publishing, we also use the runtime identifiers (check the next target "PublishApp") -->
     </PropertyGroup>
 
     <!--
       This command aims at increasing the stack size of Xilium.CefGlue.BrowserProcess.exe to 8 MiBs, using the visual studio tool "editbin".
+      Since we are reaching the .exe at the compile time, the file name is "apphost.exe" instead and located at /obj folder
       Comment it only for development purposes.
     -->
     <Exec Condition="$(RunsEditBin) == True" Command="call &quot;$(VcvarsLocation)$(VcvarsFile)&quot;&#xD;&#xA; editbin /STACK:0x800000 &quot;$(ApphostLocation)\apphost.exe&quot;&#xD;&#xA;" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
 
     <PropertyGroup>
         <PackageOutputPath>$(MSBuildProjectDirectory)\..\Nuget\output</PackageOutputPath>
-        <Version>120.6099.206</Version>
+        <Version>120.6099.207</Version>
         <Authors>XiliumHQ,OutSystems</Authors>
         <Product>CefGlue</Product>
         <AssemblyTitle>CefGlue</AssemblyTitle>


### PR DESCRIPTION
Follow up of https://github.com/OutSystems/CefGlue/pull/171.
Pipeline is now reacting to this change

Following https://github.com/chromiumembedded/cef/issues/3250 and https://bitbucket.org/chromiumembedded/cef/commits/85c53029bf07, this PR aims at increasing the cef stack size to 8 MiBs. To do so, we use the visual studio tool "editbin".

Similarly to https://github.com/cefsharp/CefSharp/blob/d0486b317967fe4a3eb00e783c26d93d2a00e594/CefSharp.BrowserSubprocess/CefSharp.BrowserSubprocess.netcore.csproj#L67, we want to run editbin after building to increase the stack size to 8 MiBs.

Differenly from the link above, I tried drying the code a bit and make it more readable.

# Results
To see a file's stack size, we can use `dumpbin` (another vs tool).
<img width="935" alt="Screenshot 2024-10-16 at 14 28 47" src="https://github.com/user-attachments/assets/826e8ce2-9183-4cf2-b105-e08d42e3c02b">

## Output of the `Xilium.CefGlue.BrowserProcess.exe` file before changes

<img width="534" alt="Screenshot 2024-10-16 at 14 29 58" src="https://github.com/user-attachments/assets/6c57b1d3-1f50-48e4-884a-fcab01effbe1">

## Output of the `Xilium.CefGlue.BrowserProcess.exe` file after changes
<img width="672" alt="Screenshot 2024-10-16 at 14 30 40" src="https://github.com/user-attachments/assets/53a17527-b98f-4406-af61-38d7188a0fb3">