### PR TITLE
Handle the case where `extraInfo` is `null`.

### DIFF
--- a/CefGlue.BrowserProcess/Handlers/RenderProcessHandler.cs
+++ b/CefGlue.BrowserProcess/Handlers/RenderProcessHandler.cs
@@ -108,9 +108,9 @@ namespace Xilium.CefGlue.BrowserProcess.Handlers
         }
 
 
-        protected override void OnBrowserCreated(CefBrowser browser, CefDictionaryValue extraInfo)
+        protected override void OnBrowserCreated(CefBrowser browser, CefDictionaryValue? extraInfo)
         {
-            _crashPipeName = extraInfo.GetString(Constants.CrashPipeNameKey);
+            _crashPipeName = extraInfo?.GetString(Constants.CrashPipeNameKey);
             _browser = browser;
             base.OnBrowserCreated(browser, extraInfo);
         }


### PR DESCRIPTION
Resolve https://github.com/OutSystems/CefGlue/issues/135

![image](https://github.com/user-attachments/assets/f4f10c77-0e54-488a-bf18-c47c0d4ba82e)
