### PR TITLE
Add PermissionHandler for Media and Permission Prompt Support

### DIFF
--- a/CefGlue.Common/BaseCefBrowser.cs
+++ b/CefGlue.Common/BaseCefBrowser.cs
@@ -201,6 +201,11 @@ namespace Xilium.CefGlue.Common
         /// Return the handler for JavaScript dialogs. If no handler is provided the default implementation will be used.
         /// </summary>
         public JSDialogHandler JSDialogHandler { get => _adapter.JSDialogHandler; set => _adapter.JSDialogHandler = value; }
+        
+        /// <summary>
+        /// Return the handler for browser permission events.
+        /// </summary>
+        public PermissionHandler PermissionHandler { get => _adapter.PermissionHandler; set => _adapter.PermissionHandler = value; }
 
         /// <summary>
         /// Gets or set the url.

--- a/CefGlue.Common/CommonBrowserAdapter.cs
+++ b/CefGlue.Common/CommonBrowserAdapter.cs
@@ -137,6 +137,7 @@ namespace Xilium.CefGlue.Common
         public DisplayHandler DisplayHandler { get; set; }
         public RenderHandler RenderHandler { get; set; }
         public JSDialogHandler JSDialogHandler { get; set; }
+        public PermissionHandler PermissionHandler { get; set; }
 
         #endregion
 

--- a/CefGlue.Common/CommonCefClient.cs
+++ b/CefGlue.Common/CommonCefClient.cs
@@ -104,6 +104,11 @@ namespace Xilium.CefGlue.Common
         {
             return _frameHandler;
         }
+        
+        protected override CefPermissionHandler GetPermissionHandler()
+        {
+            return _owner.PermissionHandler;
+        }
 
         protected override bool OnProcessMessageReceived(CefBrowser browser, CefFrame frame, CefProcessId sourceProcess, CefProcessMessage message)
         {

--- a/CefGlue.Common/Handlers/Handlers.cs
+++ b/CefGlue.Common/Handlers/Handlers.cs
@@ -103,6 +103,8 @@
     public abstract class JSDialogHandler : CefJSDialogHandler { }
 
     public class KeyboardHandler : CefKeyboardHandler { }
+    
+    public abstract class PermissionHandler : CefPermissionHandler { }
 
     public class LifeSpanHandler : CefLifeSpanHandler
     {

--- a/CefGlue.Common/ICefBrowserHost.cs
+++ b/CefGlue.Common/ICefBrowserHost.cs
@@ -41,5 +41,6 @@ namespace Xilium.CefGlue.Common
         DisplayHandler DisplayHandler { get; set; }
         RenderHandler RenderHandler { get; set; }
         JSDialogHandler JSDialogHandler { get; set; }
+        PermissionHandler PermissionHandler { get; set; }
     }
 }

--- a/CefGlue.Demo.Avalonia/BrowserView.axaml.cs
+++ b/CefGlue.Demo.Avalonia/BrowserView.axaml.cs
@@ -30,6 +30,7 @@ namespace Xilium.CefGlue.Demo.Avalonia
             browser.LoadStart += OnBrowserLoadStart;
             browser.TitleChanged += OnBrowserTitleChanged;
             browser.LifeSpanHandler = new BrowserLifeSpanHandler();
+            browser.PermissionHandler = new BrowserPermissionHandler();
             browserWrapper.Child = browser;
         }
 
@@ -166,6 +167,52 @@ namespace Xilium.CefGlue.Demo.Avalonia
                     window.Title = targetUrl;
                     window.Show();
                 });
+                return true;
+            }
+        }
+        
+        /// <summary>
+        /// Simplified permission handler for browser requests.
+        /// </summary>
+        internal sealed class BrowserPermissionHandler : PermissionHandler
+        {
+            protected override bool OnRequestMediaAccessPermission(CefBrowser browser, CefFrame frame,
+                string requestingOrigin,
+                CefMediaAccessPermissionTypes requestedPermissions, CefMediaAccessCallback callback)
+            {
+                if (browser == null || callback == null) return false;
+
+                // Grant all requested media permissions for all sites.
+                callback.Continue(requestedPermissions);
+                return true;
+            }
+
+            /// <summary>
+            /// Called when a permission prompt is shown (e.g., clipboard, geolocation, notifications).
+            /// Grants permissions for all sites. For testing, you can filter by checking requestingOrigin, 
+            /// e.g., if (requestingOrigin.Contains("test-site.com")) to restrict to specific domains.
+            /// </summary>
+            /// <param name="browser">The browser instance initiating the prompt.</param>
+            /// <param name="promptId">The unique ID of the permission prompt.</param>
+            /// <param name="requestingOrigin">The origin requesting the permission.</param>
+            /// <param name="requestedPermissions">The requested permission types.</param>
+            /// <param name="callback">The callback to invoke with the permission result.</param>
+            /// <returns>True if the prompt was handled, false otherwise.</returns>
+            protected override bool OnShowPermissionPrompt(CefBrowser browser, ulong promptId, string requestingOrigin,
+                CefPermissionRequestTypes requestedPermissions, CefPermissionPromptCallback callback)
+            {
+                if (browser == null || callback == null) return false;
+
+                // Allow clipboard, geolocation, and notifications for all sites.
+                var result = CefPermissionRequestResult.Deny;
+                if (requestedPermissions.HasFlag(CefPermissionRequestTypes.Clipboard) ||
+                    requestedPermissions.HasFlag(CefPermissionRequestTypes.Geolocation) ||
+                    requestedPermissions.HasFlag(CefPermissionRequestTypes.Notifications))
+                {
+                    result = CefPermissionRequestResult.Accept;
+                }
+
+                callback.Continue(result);
                 return true;
             }
         }


### PR DESCRIPTION
This PR adds `PermissionHandler`, extending `CefPermissionHandler`, to handle media access and permission prompts. Key changes:
- Implemented `OnRequestMediaAccessPermission` to grant media permissions (camera, microphone).
- Implemented `OnShowPermissionPrompt` to allow clipboard, geolocation, and notification permissions.
- Integrated with `CefClient` for handler registration.

Tested with both Avalonia and WPF sample apps to confirm functionality for media access (camera, microphone) and permission prompts (clipboard, geolocation, notifications).

![image](https://github.com/user-attachments/assets/09c3fbfa-ea9d-491d-ba57-5024cd48fad8)
